### PR TITLE
docs(template): align backend metadata with mise vfox

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ function PLUGIN:BackendInstall(ctx)
     http.download_file({url = url}, temp_file)
 
     cmd.exec("cd " .. ctx.install_path .. " && tar -xzf " .. temp_file)
-    cmd.exec("rm " .. temp_file)
     return {}
 end
 ```

--- a/README.md
+++ b/README.md
@@ -297,13 +297,21 @@ end
 | `ctx.tool` | string | Tool name | `"prettier"` |
 | `ctx.options` | table | Plugin options from `mise.toml` | `{}` |
 
-### BackendInstall and BackendExecEnv Context  
+### BackendInstall Context
 | Variable | Type | Description | Example |
 |----------|------|-------------|---------|
 | `ctx.tool` | string | Tool name | `"prettier"` |
 | `ctx.version` | string | Tool version | `"3.0.0"` |
 | `ctx.install_path` | string | Installation directory | `"/home/user/.local/share/mise/installs/npm/prettier/3.0.0"` |
-| `ctx.download_path` | string | Download cache directory (BackendInstall only) | `"/home/user/.local/share/mise/downloads/npm/prettier/3.0.0"` |
+| `ctx.download_path` | string | Download cache directory | `"/home/user/.local/share/mise/downloads/npm/prettier/3.0.0"` |
+| `ctx.options` | table | Plugin options from `mise.toml` | `{}` |
+
+### BackendExecEnv Context
+| Variable | Type | Description | Example |
+|----------|------|-------------|---------|
+| `ctx.tool` | string | Tool name | `"prettier"` |
+| `ctx.version` | string | Tool version | `"3.0.0"` |
+| `ctx.install_path` | string | Installation directory | `"/home/user/.local/share/mise/installs/npm/prettier/3.0.0"` |
 | `ctx.options` | table | Plugin options from `mise.toml` | `{}` |
 
 ### Available Lua Modules

--- a/README.md
+++ b/README.md
@@ -274,12 +274,11 @@ function PLUGIN:BackendInstall(ctx)
     
     local http = require("http")
     local file = require("file")
-    local cmd = require("cmd")
-    cmd.exec("mkdir -p " .. ctx.download_path)
+    local archiver = require("archiver")
     local temp_file = file.join_path(ctx.download_path, "tool.tar.gz")
     http.download_file({url = url}, temp_file)
 
-    cmd.exec("cd " .. ctx.install_path .. " && tar -xzf " .. temp_file)
+    archiver.decompress(temp_file, ctx.install_path)
     return {}
 end
 ```
@@ -322,6 +321,7 @@ Backend plugins have access to these built-in modules:
 - `http` - HTTP client for downloads and API calls  
 - `json` - JSON parsing and encoding
 - `file` - File system operations
+- `archiver` - Archive extraction
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Search and replace these placeholders throughout the project:
 - `<TEST_TOOL>` → a real tool name your backend can install (for testing)
 
 Files to update:
-- `metadata.lua` - Update name, description, author, homepage
+- `metadata.lua` - Update name, version, description, author, license, homepage, and optional metadata
 - `hooks/*.lua` - Replace placeholders and implement your backend logic
 - `mise-tasks/test` - Update test tool name and commands
 - `README.md` - Update this file with your backend's information
@@ -53,6 +53,7 @@ Lists available versions for a tool in your backend.
 ```lua
 function PLUGIN:BackendListVersions(ctx)
     local tool = ctx.tool
+    -- local options = ctx.options
     -- Your logic to fetch versions for the tool
     -- Return: {versions = {"1.0.0", "1.1.0", "2.0.0"}}
 end
@@ -71,6 +72,8 @@ function PLUGIN:BackendInstall(ctx)
     local tool = ctx.tool
     local version = ctx.version  
     local install_path = ctx.install_path
+    local download_path = ctx.download_path
+    -- local options = ctx.options
     -- Your logic to install the tool
     -- Return: {}
 end
@@ -87,6 +90,7 @@ Sets up environment variables for a tool.
 ```lua
 function PLUGIN:BackendExecEnv(ctx)
     local install_path = ctx.install_path
+    -- local options = ctx.options
     -- Your logic to set up environment
     -- Return: {env_vars = {{key = "PATH", value = install_path .. "/bin"}}}
 end
@@ -119,11 +123,11 @@ Provide meaningful error messages:
 ```lua
 function PLUGIN:BackendListVersions(ctx)
     local tool = ctx.tool
-    
+
     if not tool or tool == "" then
         error("Tool name cannot be empty")
     end
-    
+
     -- ... your implementation ...
     
     if #versions == 0 then
@@ -269,11 +273,13 @@ function PLUGIN:BackendInstall(ctx)
                 "/" .. ctx.tool .. "-" .. platform .. "-" .. arch .. ".tar.gz"
     
     local http = require("http")
-    local temp_file = ctx.install_path .. "/tool.tar.gz"
-    http.download({url = url, output = temp_file})
-    
+    local file = require("file")
     local cmd = require("cmd")
-    cmd.exec("cd " .. ctx.install_path .. " && tar -xzf tool.tar.gz")
+    cmd.exec("mkdir -p " .. ctx.download_path)
+    local temp_file = file.join_path(ctx.download_path, "tool.tar.gz")
+    http.download_file({url = url}, temp_file)
+
+    cmd.exec("cd " .. ctx.install_path .. " && tar -xzf " .. temp_file)
     cmd.exec("rm " .. temp_file)
     return {}
 end
@@ -290,6 +296,7 @@ end
 | Variable | Type | Description | Example |
 |----------|------|-------------|---------|
 | `ctx.tool` | string | Tool name | `"prettier"` |
+| `ctx.options` | table | Plugin options from `mise.toml` | `{}` |
 
 ### BackendInstall and BackendExecEnv Context  
 | Variable | Type | Description | Example |
@@ -297,6 +304,8 @@ end
 | `ctx.tool` | string | Tool name | `"prettier"` |
 | `ctx.version` | string | Tool version | `"3.0.0"` |
 | `ctx.install_path` | string | Installation directory | `"/home/user/.local/share/mise/installs/npm/prettier/3.0.0"` |
+| `ctx.download_path` | string | Download cache directory (BackendInstall only) | `"/home/user/.local/share/mise/downloads/npm/prettier/3.0.0"` |
+| `ctx.options` | table | Plugin options from `mise.toml` | `{}` |
 
 ### Available Lua Modules
 
@@ -313,15 +322,12 @@ Backend plugins have access to these built-in modules:
 2. Create a GitHub repository for your plugin
 3. Push your code
 4. Test with: `mise plugin install mybackend https://github.com/user/mise-mybackend`
-5. (Optional) Request to transfer to [mise-plugins](https://github.com/mise-plugins) organization
-6. Add to the [mise registry](https://github.com/jdx/mise/blob/main/registry.toml) via PR
 
 ## Documentation
 
 - [Backend Plugin Development](https://mise.jdx.dev/backend-plugin-development.html) - Complete guide
 - [Backend Architecture](https://mise.jdx.dev/dev-tools/backend_architecture.html) - How backends work
 - [Lua modules reference](https://mise.jdx.dev/plugin-lua-modules.html) - Available modules
-- [mise-plugins organization](https://github.com/mise-plugins) - Community plugins
 
 ## License
 

--- a/hooks/backend_exec_env.lua
+++ b/hooks/backend_exec_env.lua
@@ -1,11 +1,12 @@
 --- Sets up environment variables for a tool
 --- Documentation: https://mise.jdx.dev/backend-plugin-development.html#backendexecenv
---- @param ctx {install_path: string, tool: string, version: string} Context
+--- @param ctx BackendExecEnvCtx Context for the installed backend tool
 --- @return {env_vars: table[]} Table containing list of environment variable definitions
 function PLUGIN:BackendExecEnv(ctx)
     local install_path = ctx.install_path
     local tool = ctx.tool
     local version = ctx.version
+    -- local options = ctx.options -- Plugin options from mise.toml
 
     -- Basic PATH setup (most common case)
     local file = require("file")

--- a/hooks/backend_install.lua
+++ b/hooks/backend_install.lua
@@ -41,6 +41,7 @@ function PLUGIN:BackendInstall(ctx)
     --[[
     local http = require("http")
     local file = require("file")
+    local archiver = require("archiver")
 
     -- Construct download URL (adjust based on your backend's URL pattern)
     local platform = RUNTIME.osType:lower()
@@ -48,14 +49,13 @@ function PLUGIN:BackendInstall(ctx)
     local download_url = "https://releases.<BACKEND>.org/" .. tool .. "/" .. version .. "/" .. tool .. "-" .. platform .. "-" .. arch .. ".tar.gz"
 
     -- Download the tool
-    cmd.exec("mkdir -p " .. download_path)
     local temp_file = file.join_path(download_path, tool .. ".tar.gz")
     http.download_file({
         url = download_url
     }, temp_file)
 
     -- Extract the archive
-    cmd.exec("cd " .. install_path .. " && tar -xzf " .. temp_file)
+    archiver.decompress(temp_file, install_path)
 
     -- Set executable permissions
     cmd.exec("chmod +x " .. install_path .. "/bin/" .. tool)

--- a/hooks/backend_install.lua
+++ b/hooks/backend_install.lua
@@ -56,7 +56,6 @@ function PLUGIN:BackendInstall(ctx)
 
     -- Extract the archive
     cmd.exec("cd " .. install_path .. " && tar -xzf " .. temp_file)
-    cmd.exec("rm " .. temp_file)
 
     -- Set executable permissions
     cmd.exec("chmod +x " .. install_path .. "/bin/" .. tool)

--- a/hooks/backend_install.lua
+++ b/hooks/backend_install.lua
@@ -1,11 +1,13 @@
 --- Installs a specific version of a tool
 --- Documentation: https://mise.jdx.dev/backend-plugin-development.html#backendinstall
---- @param ctx {tool: string, version: string, install_path: string} Context
+--- @param ctx BackendInstallCtx Context for the requested backend tool installation
 --- @return table Empty table on success
 function PLUGIN:BackendInstall(ctx)
     local tool = ctx.tool
     local version = ctx.version
     local install_path = ctx.install_path
+    local download_path = ctx.download_path
+    -- local options = ctx.options -- Plugin options from mise.toml
 
     -- Validate inputs
     if not tool or tool == "" then
@@ -16,6 +18,9 @@ function PLUGIN:BackendInstall(ctx)
     end
     if not install_path or install_path == "" then
         error("Install path cannot be empty")
+    end
+    if not download_path or download_path == "" then
+        error("Download path cannot be empty")
     end
 
     -- Create installation directory
@@ -43,15 +48,11 @@ function PLUGIN:BackendInstall(ctx)
     local download_url = "https://releases.<BACKEND>.org/" .. tool .. "/" .. version .. "/" .. tool .. "-" .. platform .. "-" .. arch .. ".tar.gz"
 
     -- Download the tool
-    local temp_file = install_path .. "/" .. tool .. ".tar.gz"
-    local resp, err = http.download({
-        url = download_url,
-        output = temp_file
-    })
-
-    if err then
-        error("Failed to download " .. tool .. "@" .. version .. ": " .. err)
-    end
+    cmd.exec("mkdir -p " .. download_path)
+    local temp_file = file.join_path(download_path, tool .. ".tar.gz")
+    http.download_file({
+        url = download_url
+    }, temp_file)
 
     -- Extract the archive
     cmd.exec("cd " .. install_path .. " && tar -xzf " .. temp_file)

--- a/hooks/backend_list_versions.lua
+++ b/hooks/backend_list_versions.lua
@@ -1,9 +1,10 @@
 --- Lists available versions for a tool in this backend
 --- Documentation: https://mise.jdx.dev/backend-plugin-development.html#backendlistversions
---- @param ctx {tool: string} Context (tool = the tool name requested)
+--- @param ctx BackendListVersionsCtx Context for the requested backend tool
 --- @return {versions: string[]} Table containing list of available versions
 function PLUGIN:BackendListVersions(ctx)
     local tool = ctx.tool
+    -- local options = ctx.options -- Plugin options from mise.toml
 
     -- Validate tool name
     if not tool or tool == "" then
@@ -19,14 +20,10 @@ function PLUGIN:BackendListVersions(ctx)
     -- Replace with your backend's API endpoint
     local api_url = "https://api.<BACKEND>.org/packages/" .. tool .. "/versions"
 
-    local resp, err = http.get({
+    local resp = http.get({
         url = api_url,
         -- headers = { ["Authorization"] = "Bearer " .. token } -- if needed
     })
-
-    if err then
-        error("Failed to fetch versions for " .. tool .. ": " .. err)
-    end
 
     if resp.status_code ~= 200 then
         error("API returned status " .. resp.status_code .. " for " .. tool)

--- a/metadata.lua
+++ b/metadata.lua
@@ -3,27 +3,30 @@
 -- Documentation: https://mise.jdx.dev/backend-plugin-development.html
 
 PLUGIN = { -- luacheck: ignore
-    -- Required: Plugin name (will be the backend name users reference)
+    -- Required: Plugin metadata name
     name = "<BACKEND>",
 
-    -- Required: Plugin version (not the tool versions)
+    -- Required: Plugin metadata version
     version = "1.0.0",
 
-    -- Required: Brief description of the backend and tools it manages
+    -- Optional: Plugin description
     description = "A mise backend plugin for <BACKEND> tools",
 
-    -- Required: Plugin author/maintainer
+    -- Optional: Plugin author
     author = "<GITHUB_USER>",
 
-    -- Optional: Plugin homepage/repository URL
-    homepage = "https://github.com/<GITHUB_USER>/<BACKEND>",
-
-    -- Optional: Plugin license
+    -- Optional: License name
     license = "MIT",
 
-    -- Optional: Important notes for users
-    notes = {
-        -- "Requires <BACKEND> to be installed on your system",
-        -- "This plugin manages tools from the <BACKEND> ecosystem"
-    },
+    -- Optional: Plugin homepage
+    homepage = "https://github.com/<GITHUB_USER>/<BACKEND>",
+
+    -- Optional: Legacy version files this plugin can parse
+    -- legacyFilenames = {
+    --     ".<BACKEND>-version",
+    --     ".<BACKEND>rc",
+    -- },
+
+    -- Optional: configured mise tools to add to install-hook PATH
+    -- depends = { "node" },
 }

--- a/types/mise-plugin.lua
+++ b/types/mise-plugin.lua
@@ -9,6 +9,7 @@
 ---@class Runtime
 ---@field osType string Operating system type (e.g. "linux", "darwin", "windows")
 ---@field archType string Architecture type (e.g. "amd64", "arm64")
+---@field envType string|nil libc environment type ("gnu" on glibc Linux, "musl" on musl Linux, nil on other platforms)
 ---@field version string Runtime version
 ---@field pluginDirPath string Path to the plugin directory
 RUNTIME = {}
@@ -32,7 +33,8 @@ ARCH_TYPE = ""
 ---@field checksum? string Checksum for detecting changes in rolling releases
 
 ---@class AvailableCtx
----@field args string[] Command-line arguments
+---@field args string[]
+---@field version? string
 
 ---@class PreInstallResult
 ---@field version string Version string
@@ -54,7 +56,7 @@ ARCH_TYPE = ""
 ---@field slsa_min_level? integer Minimum SLSA level
 
 ---@class PreInstallCtx
----@field args string[] Command-line arguments
+---@field args string[]
 ---@field version string Requested version
 
 ---@class PostInstallCtx
@@ -63,9 +65,9 @@ ARCH_TYPE = ""
 ---@field sdkInfo table<string, SdkInfo> SDK info for installed versions
 
 ---@class SdkInfo
+---@field name string SDK name
 ---@field path string Installation path
 ---@field version string Installed version
----@field note? string Optional note
 
 ---@class EnvKey
 ---@field key string Environment variable name
@@ -89,17 +91,21 @@ ARCH_TYPE = ""
 
 ---@class MiseEnvCtx
 ---@field options table Plugin options from mise.toml
+---@field config_root? string Configuration root path
 
 ---@class MiseEnvResult
 ---@field env? EnvKey[] Environment variables to set
 ---@field cacheable? boolean Whether the result can be cached (default false)
 ---@field watch_files? string[] Files to watch for cache invalidation
+---@field redact? boolean Whether env vars should be redacted in output (default false)
 
 ---@class MisePathCtx
 ---@field options table Plugin options from mise.toml
+---@field config_root? string Configuration root path
 
 ---@class BackendListVersionsCtx
 ---@field tool string Tool name
+---@field options table Plugin options from mise.toml
 
 ---@class BackendListVersionsResult
 ---@field versions string[] List of available versions
@@ -108,6 +114,8 @@ ARCH_TYPE = ""
 ---@field tool string Tool name
 ---@field version string Version to install
 ---@field install_path string Path where the tool should be installed
+---@field download_path string Path where the tool artifact should be downloaded
+---@field options table Plugin options from mise.toml
 
 ---@class BackendInstallResult
 
@@ -115,12 +123,21 @@ ARCH_TYPE = ""
 ---@field tool string Tool name
 ---@field version string Installed version
 ---@field install_path string Installation path
+---@field options table Plugin options from mise.toml
 
 ---@class BackendExecEnvResult
 ---@field env_vars EnvKey[] Environment variables to set
 
 ---@class Plugin
----@field name string Plugin name
+--- Keys for `metadata.lua` (mise loads these via vfox `Metadata`). Hook methods are separate optional entries on the same table.
+---@field name string Plugin metadata name
+---@field version string Plugin metadata version
+---@field description? string Plugin description
+---@field author? string Plugin author
+---@field license? string License name
+---@field homepage? string Plugin homepage
+---@field legacyFilenames? string[] Legacy version filenames
+---@field depends? string[] Configured mise tools whose bin paths should be available during install hooks
 ---@field Available? fun(self: Plugin, ctx: AvailableCtx): AvailableVersion[]
 ---@field PreInstall? fun(self: Plugin, ctx: PreInstallCtx): PreInstallResult
 ---@field PostInstall? fun(self: Plugin, ctx: PostInstallCtx)


### PR DESCRIPTION
## Summary

- Align `metadata.lua` with the fields mise parses from vfox `Metadata`.
- Update LuaCATS definitions and backend hook docs for `options`, `download_path`, `envType`, `config_root`, and `redact`.
- Use `http.download_file` in backend download examples and remove registry/org publishing checklist items.

## Implementation checked

- `../mise/crates/vfox/src/metadata.rs`
- `../mise/crates/vfox/src/hooks/backend_list_versions.rs`
- `../mise/crates/vfox/src/hooks/backend_install.rs`
- `../mise/crates/vfox/src/hooks/backend_exec_env.rs`
- `../mise/crates/vfox/src/lua_mod/http.rs`

## Verification

- `git diff --check`
- `mise run lint`
- `mise run ci` fails on a pre-existing template test issue: `mise-tasks/test` uses unquoted `<BACKEND>`, which the shell treats as input redirection before any backend hook runs.